### PR TITLE
Fix ScottPlot scatter type declarations

### DIFF
--- a/VineRobotControlApp/MainWindow.xaml.cs
+++ b/VineRobotControlApp/MainWindow.xaml.cs
@@ -16,8 +16,8 @@ public partial class MainWindow : Window
     private readonly List<double> _rawPsiPoints = new();
     private readonly List<double> _filteredPsiPoints = new();
     private readonly List<double> _sampleIndex = new();
-    private Scatter? _rawScatter;
-    private Scatter? _filteredScatter;
+    private ScatterPlot? _rawScatter;
+    private ScatterPlot? _filteredScatter;
 
     public MainViewModel ViewModel { get; }
 


### PR DESCRIPTION
## Summary
- update the scatter plot field declarations in `MainWindow` to use `ScatterPlot`
- ensure the fields align with the ScottPlot API used in `ConfigurePlot`

## Testing
- `dotnet build VineRobotControlApp.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e619d29aac832faab2608978958990