### PR TITLE
Fix ScottPlot integration for WPF app

### DIFF
--- a/VineRobotControlApp/MainWindow.xaml.cs
+++ b/VineRobotControlApp/MainWindow.xaml.cs
@@ -1,8 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Threading.Tasks;
-using System.Drawing;
-using ScottPlot.Plottable;
+using ScottPlot;
+using ScottPlot.Plottables;
 using VineRobotControlApp.Models;
 using VineRobotControlApp.Services;
 using VineRobotControlApp.ViewModels;
@@ -16,8 +16,8 @@ public partial class MainWindow : Window
     private readonly List<double> _rawPsiPoints = new();
     private readonly List<double> _filteredPsiPoints = new();
     private readonly List<double> _sampleIndex = new();
-    private ScatterPlot? _rawScatter;
-    private ScatterPlot? _filteredScatter;
+    private Scatter? _rawScatter;
+    private Scatter? _filteredScatter;
 
     public MainViewModel ViewModel { get; }
 
@@ -40,15 +40,20 @@ public partial class MainWindow : Window
 
     private void ConfigurePlot()
     {
-        PressurePlot.Plot.Title("Pressure History");
-        PressurePlot.Plot.XLabel("Sample");
-        PressurePlot.Plot.YLabel("PSI");
-        PressurePlot.Plot.Legend(location: ScottPlot.Alignment.UpperRight);
+        var plot = PressurePlot.Plot;
+        plot.Title("Pressure History");
+        plot.XLabel("Sample");
+        plot.YLabel("PSI");
+        plot.ShowLegend(Alignment.UpperRight);
 
-        _rawScatter = PressurePlot.Plot.AddScatter(Array.Empty<double>(), Array.Empty<double>(), label: "Raw");
-        _rawScatter.Color = System.Drawing.Color.LightGray;
-        _filteredScatter = PressurePlot.Plot.AddScatter(Array.Empty<double>(), Array.Empty<double>(), label: "Filtered");
-        _filteredScatter.Color = System.Drawing.Color.DeepSkyBlue;
+        _rawScatter = plot.Add.Scatter(_sampleIndex, _rawPsiPoints);
+        _rawScatter.LegendText = "Raw";
+        _rawScatter.LineStyle.Color = Colors.Gray.WithAlpha(.6);
+
+        _filteredScatter = plot.Add.Scatter(_sampleIndex, _filteredPsiPoints);
+        _filteredScatter.LegendText = "Filtered";
+        _filteredScatter.LineStyle.Color = Colors.Blue;
+        _filteredScatter.LineStyle.Width = 2;
         PressurePlot.Refresh();
     }
 
@@ -213,8 +218,7 @@ public partial class MainWindow : Window
                 _filteredPsiPoints.RemoveAt(0);
             }
 
-            _rawScatter?.Update(_sampleIndex.ToArray(), _rawPsiPoints.ToArray());
-            _filteredScatter?.Update(_sampleIndex.ToArray(), _filteredPsiPoints.ToArray());
+            PressurePlot.Plot.Axes.AutoScale();
             PressurePlot.Refresh();
         });
     }

--- a/VineRobotControlApp/Models/SegmentSetpoint.cs
+++ b/VineRobotControlApp/Models/SegmentSetpoint.cs
@@ -1,66 +1,67 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace VineRobotControlApp.Models;
-
-public class SegmentSetpoint : INotifyPropertyChanged
+namespace VineRobotControlApp.Models
 {
-    private double _psi;
-    private int _expectedAdc;
-    private bool _isSelected;
-
-    public PouchSide Side { get; }
-    public int Segment { get; }
-    public PressureCalibration Calibration { get; }
-
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    public SegmentSetpoint(PouchSide side, int segment, PressureCalibration calibration)
+    public class SegmentSetpoint : INotifyPropertyChanged
     {
-        Side = side;
-        Segment = segment;
-        Calibration = calibration;
-        Calibration.CalibrationChanged += (_, _) => UpdateExpectedAdc();
-        UpdateExpectedAdc();
-    }
+        private double _psi;
+        private int _expectedAdc;
+        private bool _isSelected;
 
-    public double Psi
-    {
-        get => _psi;
-        set
+        public PouchSide Side { get; }
+        public int Segment { get; }
+        public PressureCalibration Calibration { get; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public SegmentSetpoint(PouchSide side, int segment, PressureCalibration calibration)
         {
-            if (SetField(ref _psi, value))
+            Side = side;
+            Segment = segment;
+            Calibration = calibration;
+            Calibration.CalibrationChanged += (_, _) => UpdateExpectedAdc();
+            UpdateExpectedAdc();
+        }
+
+        public double Psi
+        {
+            get => _psi;
+            set
             {
-                UpdateExpectedAdc();
+                if (SetField(ref _psi, value))
+                {
+                    UpdateExpectedAdc();
+                }
             }
         }
-    }
 
-    public int ExpectedAdc
-    {
-        get => _expectedAdc;
-        private set => SetField(ref _expectedAdc, value);
-    }
+        public int ExpectedAdc
+        {
+            get => _expectedAdc;
+            private set => SetField(ref _expectedAdc, value);
+        }
 
-    public bool IsSelected
-    {
-        get => _isSelected;
-        set => SetField(ref _isSelected, value);
-    }
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set => SetField(ref _isSelected, value);
+        }
 
-    public string DisplayName => $"{Side} S{Segment}";
+        public string DisplayName => $"{Side} S{Segment}";
 
-    public void UpdateExpectedAdc()
-    {
-        ExpectedAdc = Calibration.PsiToAdc(Psi);
-    }
+        public void UpdateExpectedAdc()
+        {
+            ExpectedAdc = Calibration.PsiToAdc(Psi);
+        }
 
-    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-    {
-        if (EqualityComparer<T>.Default.Equals(field, value))
-            return false;
-        field = value;
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        return true;
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+                return false;
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
     }
 }

--- a/VineRobotControlApp/SelectedBrushConverter.cs
+++ b/VineRobotControlApp/SelectedBrushConverter.cs
@@ -3,25 +3,26 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media;
 
-namespace VineRobotControlApp;
-
-public class SelectedBrushConverter : IValueConverter
+namespace VineRobotControlApp
 {
-    private static readonly SolidColorBrush ActiveBrush = new(Color.FromRgb(34, 197, 94));
-    private static readonly SolidColorBrush InactiveBrush = new(Color.FromRgb(209, 213, 219));
-
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public class SelectedBrushConverter : IValueConverter
     {
-        if (value is bool isSelected && isSelected)
+        private static readonly SolidColorBrush ActiveBrush = new(Color.FromRgb(34, 197, 94));
+        private static readonly SolidColorBrush InactiveBrush = new(Color.FromRgb(209, 213, 219));
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return ActiveBrush;
+            if (value is bool isSelected && isSelected)
+            {
+                return ActiveBrush;
+            }
+
+            return InactiveBrush;
         }
 
-        return InactiveBrush;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- use block-scoped namespaces for value converters and models so they resolve correctly from XAML
- update the pressure plot configuration to the ScottPlot 5 API and keep data lists in sync with autoscaling

## Testing
- `dotnet build VineRobotControlApp/VineRobotControlApp.csproj` *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e62fae89dc832fa2be69e42c8b1763